### PR TITLE
offload my emoticon stash

### DIFF
--- a/emojis.plugin.zsh
+++ b/emojis.plugin.zsh
@@ -1,5 +1,3 @@
-#! /bin/zsh
-
 # contains numerous variables for common ascii emojis
 # Sources:
 # * http://www.emoticonfun.org/
@@ -11,12 +9,28 @@ export em_cute_face='(｡◕‿◕｡)'
 export em_excited='☜(⌒▽⌒)☞'
 export em_fisticuffs='ლ(｀ー´ლ)'
 export em_fliptable='(╯°□°）╯︵ ┻━┻'
+export em_person_flip_table=$em_fliptable
+export em_person_flip_person='(╯°Д°）╯︵/(.□ . \)\'
+export em_table_flip_person='ノ┬─┬ノ ︵ ( \o°o)\'
+export em_person_unflip_table='┬──┬◡ﾉ(° -°ﾉ)'
 export em_happy='ヽ(´▽`)/'
 export em_innocent='ʘ‿ʘ'
 export em_kirby='⊂(◉‿◉)つ'
 export em_lennyface='( ͡° ͜ʖ ͡°)'
 export em_lion='°‿‿°'
 export em_muscleflex='ᕙ(⇀‸↼‶)ᕗ'
+export em_muscleflex2='ᕦ(∩◡∩)ᕤ'
 export em_perky='(`・ω・´)'
 export em_piggy='( ́・ω・`)'
 export em_shrug='¯\_(ツ)_/¯'
+export em_point_right='(☞ﾟヮﾟ)☞'
+export em_point_left='☜(ﾟヮﾟ☜)'
+export em_magic='╰(•̀ 3 •́)━☆ﾟ.*･｡ﾟ'
+export em_shades='(•_•)
+( •_•)>⌐■-■
+(⌐■_■)'
+export em_disapprove='ಠ_ಠ'
+export em_wink='ಠ‿↼'
+export em_facepalm='(－‸ლ)'
+export em_hataz_gon_hate='ᕕ( ᐛ )ᕗ'
+export em_salute='(￣^￣)ゞ'


### PR DESCRIPTION
also removed the #! from the top for a couple reasons
1. not all platforms can access /bin/ (e.g. termux on android)
2. i figured that'd already be handled by virtue of the fact that they're using it as a zsh plugin